### PR TITLE
refactor(python): refactor ipython alias

### DIFF
--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -44,7 +44,7 @@ function pyuserpaths() {
 alias pygrep='grep -nr --include="*.py"'
 
 # Run proper IPython regarding current virtualenv (if any)
-alias ipython="python3 -c 'import IPython; IPython.terminal.ipapp.launch_new_instance()'"
+alias ipython='python3 -m IPython'
 
 # Share local directory as a HTTP server
 alias pyserver="python3 -m http.server"


### PR DESCRIPTION
refactor ipython alias to use module option instead of code option.

This is a simpler aproach that will also give a more concise and informative error message when ipython isn't installed in the current env.

Old error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'IPython'
```

New error:
`/usr/bin/python3: No module named IPython`

This change still keeps the functionality intended by this alias #5797


## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.